### PR TITLE
PBXX-9851 tracing in clients

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -115,12 +115,12 @@ func (c *client) MakeRequest(ctx context.Context, method string, slug string, qu
 		if span != nil {
 			childSpan = opentracing.StartSpan(operation, opentracing.ChildOf(span.Context()))
 			defer childSpan.Finish()
+			opentracing.GlobalTracer().Inject(childSpan.Context(), opentracing.HTTPHeaders, req.Header)
 		} else {
 			span = opentracing.StartSpan(operation)
 			defer span.Finish()
 		}
 
-		opentracing.GlobalTracer().Inject(childSpan.Context(), opentracing.HTTPHeaders, req.Header)
 		req = req.WithContext(ctx)
 
 		// if we have a requestID in the context pass it along in the header


### PR DESCRIPTION
Modifies:
1. Client.MakeRequest() to pass through any span information that might be within the context of a request