### PR TITLE
Add HTTP status to error returned from `Do()`

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -74,7 +74,10 @@ func (c *client) Do(ctx context.Context, method string, slug string, query url.V
 		if err != nil {
 			return glitch.NewDataError(err, ErrorRequestError, "Could not decode error response")
 		}
-		return glitch.FromHTTPProblem(prob, fmt.Sprintf("Error from %s to %s - %s", method, c.serviceName, slug))
+
+		problem := glitch.FromHTTPProblem(prob, fmt.Sprintf("Error from %s to %s - %s", method, c.serviceName, slug))
+		problem.AddField("status.http", status)
+		return problem
 	}
 
 	if response != nil {

--- a/vendor/github.com/promoboxx/go-glitch/glitch/data.go
+++ b/vendor/github.com/promoboxx/go-glitch/glitch/data.go
@@ -17,13 +17,22 @@ type DataError interface {
 	Wrap(err DataError) DataError
 	// GetCause will return the cause of this error
 	GetCause() DataError
+	// GetFields returns the extra fields for giving better error descriptions
+	GetFields() map[string]interface{}
+	// AddFields will add fields to the given DataErrors fields
+	AddFields(map[string]interface{})
+	// AddField will add the key and value pair to the data errors fields
+	AddField(key string, value interface{})
+	// String implements the string interface for %s in fmt calls
+	String() string
 }
 
 type dataError struct {
-	inner error
-	code  string
-	msg   string
-	cause DataError
+	inner  error
+	code   string
+	msg    string
+	cause  DataError
+	fields map[string]interface{}
 }
 
 func (d *dataError) Error() string {
@@ -47,6 +56,27 @@ func (d *dataError) GetCause() DataError {
 	return d.cause
 }
 
+func (d *dataError) GetFields() map[string]interface{} {
+	return d.fields
+}
+
+// AddFields adds the given fields to the data error
+// NOTE: Any field given that matches one in the data DataErrors
+// fields already will overwrite it
+func (d *dataError) AddFields(fields map[string]interface{}) {
+	for k, v := range fields {
+		d.AddField(k, v)
+	}
+}
+
+func (d *dataError) AddField(key string, value interface{}) {
+	d.fields[key] = value
+}
+
+func (d *dataError) String() string {
+	return d.Error()
+}
+
 // FromHTTPProblem will create a DataError from an HTTPProblem
 func FromHTTPProblem(inner error, msg string) DataError {
 	if httpProblem, ok := inner.(HTTPProblem); ok {
@@ -57,5 +87,5 @@ func FromHTTPProblem(inner error, msg string) DataError {
 
 // NewDataError will create a DataError from the information provided
 func NewDataError(inner error, code string, msg string) DataError {
-	return &dataError{inner: inner, code: code, msg: msg}
+	return &dataError{inner: inner, code: code, msg: msg, fields: map[string]interface{}{}}
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -45,10 +45,10 @@
 			"revisionTime": "2018-09-18T08:52:46Z"
 		},
 		{
-			"checksumSHA1": "LGWG8O54kxuxOE1cSBkON2fCxzQ=",
+			"checksumSHA1": "1H49vI5QrsvWkSoQTYETf7t2j5k=",
 			"path": "github.com/promoboxx/go-glitch/glitch",
-			"revision": "040ea832d91afed0e7e6b5fad7df4f8e8e3bed59",
-			"revisionTime": "2018-12-13T20:25:42Z"
+			"revision": "1ea9cd79b0f8b184350ab05372f17c0a5ee6c321",
+			"revisionTime": "2019-03-27T16:38:52Z"
 		},
 		{
 			"checksumSHA1": "BzcrXuVmF/3aAUsi0gQGGD6WsmU=",


### PR DESCRIPTION
The issue prompting this change was the need to inform calling services that the error was transient. Our particular case was Facebook throwing HTTP 503 in return to our calls. While the other Facebook error data is returned up the chain, we lose the context that the error happened but was considered transient by Facebook.

This change vendors in the latest `go-glitch` to make use of the ability to add additional fields to the error. Here, we add a new `status.http` field holding the HTTP status code. This requires no changes to existing code to keep using `go-client`, but it allows one to probe for the field and take action based on the value, if present.